### PR TITLE
Add scheduled workflow for updating latest images

### DIFF
--- a/.github/workflows/update-latest-images.yml
+++ b/.github/workflows/update-latest-images.yml
@@ -1,0 +1,50 @@
+name: Update Latest Images
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight
+  workflow_dispatch:
+
+jobs:
+  update-latest-images:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: List all images tagged with 'latest'
+        id: list_latest_images
+        run: |
+          # List all images tagged with 'latest' in the repository
+          ghcr_images=$(gh api -H "Accept: application/vnd.github.v3+json" /user/packages/container | jq -r '.[] | select(.name | contains("dockerhub-")) | .name')
+          echo "Found images: $ghcr_images"
+          echo "images=$ghcr_images" >> $GITHUB_ENV
+
+      - name: Update each 'latest' image
+        run: |
+          for image in ${{ env.images }}; do
+            echo "Processing image: $image"
+
+            # Pull the latest image from Docker Hub
+            docker pull "docker.io/$image:latest"
+
+            # Tag the image for GitHub Packages
+            docker tag "docker.io/$image:latest" "ghcr.io/${{ github.repository_owner }}/$image:latest"
+
+            # Push the image to GitHub Packages
+            docker push "ghcr.io/${{ github.repository_owner }}/$image:latest"
+          done

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ To update an image tagged as "latest" to the newest version available:
 3. Submit the issue
 4. The system will detect it's a duplicate request for a "latest" image and automatically update it
 
+### Scheduled Updates for Latest Images
+
+A scheduled workflow has been added to automatically update all images tagged with 'latest' on a daily basis. This ensures that the latest images are always up-to-date without requiring manual intervention. Additionally, you can manually trigger the workflow using the `workflow_dispatch` event for immediate synchronization.
+
 ## Audit Information
 
 Each image import includes the following audit information:


### PR DESCRIPTION
Add a scheduled workflow to update images tagged with 'latest' periodically.

* **New Workflow**: Add `.github/workflows/update-latest-images.yml` to schedule periodic updates for images tagged with 'latest'.
  - Use `on: schedule` to run the workflow daily.
  - Add `workflow_dispatch` to allow manual synchronization.
  - Add a job to iterate through all images tagged with 'latest' and trigger the update process.
* **README Update**: Update `README.md` to include information about the new scheduled workflow for periodic updates of 'latest' images.
  - Add a section to describe the new scheduled workflow.
  - Mention the manual synchronization option using `workflow_dispatch`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/codaqui/libertyhub/pull/7?shareId=6fd4019d-4237-4b72-a394-44465a7c8649).